### PR TITLE
Allow for defining if the user want to train on CUDA or CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ python tkbc/process_gdelt.py
 ## Run the Experiments
 
 ```
-python tkbc/learner.py --dataset ICEWS14 --model TLT_KGE_Quaternion --rank 1200 --emb_reg 3e-3 --time_reg 3e-2 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120
-python tkbc/learner.py --dataset ICEWS14 --model TLT_KGE_Complex --rank 1200 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120
-python tkbc/learner.py --dataset ICEWS05-15 --model TLT_KGE_Quaternion --rank 1200 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 1440
-python tkbc/learner.py --dataset ICEWS05-15 --model TLT_KGE_Complex --rank 1200 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 1440
-python tkbc/learner.py --dataset gdelt --model TLT_KGE_Quaternion --rank 1500 --emb_reg 5e-4 --time_reg 3e-2 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120
-python tkbc/learner.py --dataset gdelt --model TLT_KGE_Complex --rank 1500 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120
+python tkbc/learner.py --dataset ICEWS14 --model TLT_KGE_Quaternion --rank 1200 --emb_reg 3e-3 --time_reg 3e-2 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120 --gpu 1
+python tkbc/learner.py --dataset ICEWS14 --model TLT_KGE_Complex --rank 1200 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120 --gpu 1
+python tkbc/learner.py --dataset ICEWS05-15 --model TLT_KGE_Quaternion --rank 1200 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 1440 --gpu 1
+python tkbc/learner.py --dataset ICEWS05-15 --model TLT_KGE_Complex --rank 1200 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 1440 --gpu 1
+python tkbc/learner.py --dataset gdelt --model TLT_KGE_Quaternion --rank 1500 --emb_reg 5e-4 --time_reg 3e-2 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120 --gpu 1
+python tkbc/learner.py --dataset gdelt --model TLT_KGE_Complex --rank 1500 --emb_reg 1e-3 --time_reg 1e-1 --valid_freq 5 --max_epoch 200 --learning_rate 0.1 --batch_size 1000  --cycle 120 --gpu 1
 ```
 
 ## Citation

--- a/tkbc/learner.py
+++ b/tkbc/learner.py
@@ -79,7 +79,7 @@ args = parser.parse_args()
 save_path = "expe_log/{}_{}_{}_{}_{}_{}_{}_{}".format(args.dataset, args.model, args.rank, args.learning_rate, args.emb_reg, args.time_reg, args.cycle, int(time.time()))
 if not os.path.exists(save_path):
     os.makedirs(save_path) 
-dataset = TemporalDataset(args.dataset)
+dataset = TemporalDataset(args.dataset, is_cuda=True if args.gpu == 1 else False)
 fw = codecs.open("{}/log.txt".format(save_path), 'w')
 sizes = dataset.get_shape()
 model = {

--- a/tkbc/learner.py
+++ b/tkbc/learner.py
@@ -69,6 +69,10 @@ parser.add_argument(
     help="time range for sharing"
 )
 
+parser.add_argument(
+    '--gpu', default=0, type=int,
+    help="Use CUDA for training"
+)
 
 args = parser.parse_args()
 
@@ -79,12 +83,17 @@ dataset = TemporalDataset(args.dataset)
 fw = codecs.open("{}/log.txt".format(save_path), 'w')
 sizes = dataset.get_shape()
 model = {
-    'TComplEx': TComplEx(sizes, args.rank, no_time_emb=args.no_time_emb),
-    'TNTComplEx': TNTComplEx(sizes, args.rank, no_time_emb=args.no_time_emb),
-    'TLT_KGE_Complex':TLT_KGE_Complex(sizes, args.rank, cycle=args.cycle),
-    'TLT_KGE_Quaternion':TLT_KGE_Quaternion(sizes, args.rank, cycle=args.cycle),
+    'TComplEx': TComplEx(sizes, args.rank, no_time_emb=args.no_time_emb, is_cuda=True if args.gpu == 1 else False),
+    'TNTComplEx': TNTComplEx(sizes, args.rank, no_time_emb=args.no_time_emb, is_cuda=True if args.gpu == 1 else False),
+    'TLT_KGE_Complex':TLT_KGE_Complex(sizes, args.rank, cycle=args.cycle, is_cuda=True if args.gpu == 1 else False),
+    'TLT_KGE_Quaternion':TLT_KGE_Quaternion(sizes, args.rank, cycle=args.cycle, is_cuda=True if args.gpu == 1 else False),
 }[args.model]
-model = model.cuda()
+# in case a user want to train on a non-cuda machine
+if args.gpu == 0:
+    model = model.to('cpu')
+else:
+    model = model.cuda()
+
 best_hits1 = 0
 best_res_test = {}
 
@@ -105,14 +114,14 @@ for epoch in range(args.max_epochs):
     if dataset.has_intervals():
         optimizer = IKBCOptimizer(
             model, emb_reg, time_reg, opt, dataset,
-            batch_size=args.batch_size, add_reg = add_reg
+            batch_size=args.batch_size, add_reg = add_reg, is_cuda = True if args.gpu == 1 else False
         )
         optimizer.epoch(examples)
 
     else:
         optimizer = TKBCOptimizer(
             model, emb_reg, time_reg, opt,
-            batch_size=args.batch_size, add_reg = add_reg
+            batch_size=args.batch_size, add_reg = add_reg, is_cuda=True if args.gpu == 1 else False
         )
         optimizer.epoch(examples)
 

--- a/tkbc/models.py
+++ b/tkbc/models.py
@@ -106,7 +106,7 @@ class TKBCModel(nn.Module, ABC):
                 scores = self.forward_over_time(these_queries)
                 all_scores.append(scores.cpu().numpy())
                 if all_ts_ids is None:
-                    all_ts_ids = torch.arange(0, scores.shape[1]).to('cpu')[None, :]
+                    all_ts_ids = torch.arange(0, scores.shape[1]).to('cuda' if self.is_cuda else 'cpu')[None, :]
                 assert not torch.any(torch.isinf(scores) + torch.isnan(scores)), "inf or nan scores"
                 truth = (all_ts_ids <= these_queries[:, 4][:, None]) * (all_ts_ids >= these_queries[:, 3][:, None])
                 all_truth.append(truth.cpu().numpy())

--- a/tkbc/models.py
+++ b/tkbc/models.py
@@ -106,7 +106,7 @@ class TKBCModel(nn.Module, ABC):
                 scores = self.forward_over_time(these_queries)
                 all_scores.append(scores.cpu().numpy())
                 if all_ts_ids is None:
-                    all_ts_ids = torch.arange(0, scores.shape[1]).cuda()[None, :]
+                    all_ts_ids = torch.arange(0, scores.shape[1]).to('cpu')[None, :]
                 assert not torch.any(torch.isinf(scores) + torch.isnan(scores)), "inf or nan scores"
                 truth = (all_ts_ids <= these_queries[:, 4][:, None]) * (all_ts_ids >= these_queries[:, 3][:, None])
                 all_truth.append(truth.cpu().numpy())
@@ -161,7 +161,7 @@ class TKBCModel(nn.Module, ABC):
 class TLT_KGE_Quaternion(TKBCModel):
     def __init__(
             self, sizes: Tuple[int, int, int, int], rank: int,
-            init_size: float = 1e-3, cycle=365
+            init_size: float = 1e-3, cycle=365, is_cuda:bool=False
     ):
         super(TLT_KGE_Quaternion, self).__init__()
         self.model_name = "TLT_KGE_Quaternion"
@@ -179,6 +179,7 @@ class TLT_KGE_Quaternion(TKBCModel):
             nn.Embedding(sizes[3]//self.cycle + 1, 2*rank, sparse=True),
             nn.Embedding(sizes[3]//self.cycle + 1, 2*rank, sparse=True),
         ])
+        self.is_cuda = is_cuda
         
         if rank % 2 != 0:
             raise "rank need to be devided by 2.."
@@ -276,7 +277,7 @@ class TLT_KGE_Quaternion(TKBCModel):
 class TLT_KGE_Complex(TKBCModel):
     def __init__(
             self, sizes: Tuple[int, int, int, int], rank: int,
-            init_size: float = 1e-3, cycle=365
+            init_size: float = 1e-3, cycle=365, is_cuda = False
     ):
         super(TLT_KGE_Complex, self).__init__()
         self.cycle = cycle
@@ -296,6 +297,7 @@ class TLT_KGE_Complex(TKBCModel):
             nn.Embedding(sizes[3]//self.cycle + 1, 2*rank, sparse=True),
             nn.Embedding(sizes[3]//self.cycle + 1, 2*rank, sparse=True),
         ])
+        self.is_cuda = is_cuda
         if rank % 2 != 0:
             raise "rank need to be devided by 2.."
         for i in range(len(self.embeddings)):
@@ -393,7 +395,7 @@ class TLT_KGE_Complex(TKBCModel):
 class TComplEx(TKBCModel):
     def __init__(
             self, sizes: Tuple[int, int, int, int], rank: int,
-            no_time_emb=False, init_size: float = 1e-2
+            no_time_emb=False, init_size: float = 1e-2, is_cuda:bool=False
     ):
         super(TComplEx, self).__init__()
         self.sizes = sizes
@@ -409,6 +411,7 @@ class TComplEx(TKBCModel):
         self.embeddings[2].weight.data *= init_size
 
         self.no_time_emb = no_time_emb
+        self.is_cuda=is_cuda
 
     @staticmethod
     def has_time():
@@ -500,7 +503,7 @@ class TComplEx(TKBCModel):
 class TNTComplEx(TKBCModel):
     def __init__(
             self, sizes: Tuple[int, int, int, int], rank: int,
-            no_time_emb=False, init_size: float = 1e-2
+            no_time_emb=False, init_size: float = 1e-2, is_cuda:bool=False
     ):
         super(TNTComplEx, self).__init__()
         self.model_name = "TNTComplEx"
@@ -517,6 +520,7 @@ class TNTComplEx(TKBCModel):
         self.embeddings[3].weight.data *= init_size
 
         self.no_time_emb = no_time_emb
+        self.is_cuda=is_cuda
 
     @staticmethod
     def has_time():

--- a/tkbc/optimizers.py
+++ b/tkbc/optimizers.py
@@ -15,7 +15,7 @@ class TKBCOptimizer(object):
             self, model: TKBCModel,
             emb_regularizer: Regularizer, temporal_regularizer: Regularizer,
             optimizer: optim.Optimizer, batch_size: int = 256,
-            verbose: bool = True, add_reg=None
+            verbose: bool = True, add_reg=None, is_cuda:bool = False
     ):
         self.model = model
         self.emb_regularizer = emb_regularizer
@@ -24,6 +24,7 @@ class TKBCOptimizer(object):
         self.optimizer = optimizer
         self.batch_size = batch_size
         self.verbose = verbose
+        self.is_cuda = is_cuda
 
     def epoch(self, examples: torch.LongTensor):
         actual_examples = examples[torch.randperm(examples.shape[0]), :]
@@ -34,7 +35,7 @@ class TKBCOptimizer(object):
             while b_begin < examples.shape[0]:
                 input_batch = actual_examples[
                     b_begin:b_begin + self.batch_size
-                ].cuda()
+                ].to('cpu')
                 predictions, factors, time = self.model.forward(input_batch)
                 truth = input_batch[:, 2]
 
@@ -68,7 +69,7 @@ class IKBCOptimizer(object):
             self, model: TKBCModel,
             emb_regularizer: Regularizer, temporal_regularizer: Regularizer,
             optimizer: optim.Optimizer, dataset: TemporalDataset, batch_size: int = 256,
-            verbose: bool = True, add_reg=None
+            verbose: bool = True, add_reg=None, is_cuda: bool=False
     ):
         self.model = model
         self.dataset = dataset
@@ -78,6 +79,7 @@ class IKBCOptimizer(object):
         self.optimizer = optimizer
         self.batch_size = batch_size
         self.verbose = verbose
+        self.is_cuda = is_cuda
 
     def epoch(self, examples: torch.LongTensor):
         actual_examples = examples[torch.randperm(examples.shape[0]), :]
@@ -86,11 +88,11 @@ class IKBCOptimizer(object):
             bar.set_description(f'train loss')
             b_begin = 0
             while b_begin < examples.shape[0]:
-                time_range = actual_examples[b_begin:b_begin + self.batch_size].cuda()
+                time_range = actual_examples[b_begin:b_begin + self.batch_size].to('cpu')
 
                 ## RHS Prediction loss
                 sampled_time = (
-                        torch.rand(time_range.shape[0]).cuda() * (time_range[:, 4] - time_range[:, 3]).float() +
+                        torch.rand(time_range.shape[0]).to('cpu') * (time_range[:, 4] - time_range[:, 3]).float() +
                         time_range[:, 3].float()
                 ).round().long()
                 with_time = torch.cat((time_range[:, 0:3], sampled_time.unsqueeze(1)), 1)
@@ -109,11 +111,11 @@ class IKBCOptimizer(object):
                     ) # NOT no begin and no end
                     these_examples = time_range[filtering, :]
                     truth = (
-                            torch.rand(these_examples.shape[0]).cuda() * (these_examples[:, 4] - these_examples[:, 3]).float() +
+                            torch.rand(these_examples.shape[0]).to('cpu') * (these_examples[:, 4] - these_examples[:, 3]).float() +
                             these_examples[:, 3].float()
                     ).round().long()
-                    time_predictions = self.model.forward_over_time(these_examples[:, :3].cuda().long())
-                    time_loss = loss(time_predictions, truth.cuda())
+                    time_predictions = self.model.forward_over_time(these_examples[:, :3].to('cpu').long())
+                    time_loss = loss(time_predictions, truth.to('cpu'))
 
                 l_reg = self.emb_regularizer.forward(factors)
                 l_time = torch.zeros_like(l_reg)

--- a/tkbc/optimizers.py
+++ b/tkbc/optimizers.py
@@ -35,7 +35,7 @@ class TKBCOptimizer(object):
             while b_begin < examples.shape[0]:
                 input_batch = actual_examples[
                     b_begin:b_begin + self.batch_size
-                ].to('cpu')
+            ].to('cuda' if self.is_cuda else 'cpu')
                 predictions, factors, time = self.model.forward(input_batch)
                 truth = input_batch[:, 2]
 
@@ -88,11 +88,11 @@ class IKBCOptimizer(object):
             bar.set_description(f'train loss')
             b_begin = 0
             while b_begin < examples.shape[0]:
-                time_range = actual_examples[b_begin:b_begin + self.batch_size].to('cpu')
+                time_range = actual_examples[b_begin:b_begin + self.batch_size].to('cuda' if self.is_cuda else 'cpu')
 
                 ## RHS Prediction loss
                 sampled_time = (
-                        torch.rand(time_range.shape[0]).to('cpu') * (time_range[:, 4] - time_range[:, 3]).float() +
+                        torch.rand(time_range.shape[0]).to('cuda' if self.is_cuda else 'cpu') * (time_range[:, 4] - time_range[:, 3]).float() +
                         time_range[:, 3].float()
                 ).round().long()
                 with_time = torch.cat((time_range[:, 0:3], sampled_time.unsqueeze(1)), 1)
@@ -111,11 +111,11 @@ class IKBCOptimizer(object):
                     ) # NOT no begin and no end
                     these_examples = time_range[filtering, :]
                     truth = (
-                            torch.rand(these_examples.shape[0]).to('cpu') * (these_examples[:, 4] - these_examples[:, 3]).float() +
+                            torch.rand(these_examples.shape[0]).to('cuda' if self.is_cuda else 'cpu') * (these_examples[:, 4] - these_examples[:, 3]).float() +
                             these_examples[:, 3].float()
                     ).round().long()
-                    time_predictions = self.model.forward_over_time(these_examples[:, :3].to('cpu').long())
-                    time_loss = loss(time_predictions, truth.to('cpu'))
+                    time_predictions = self.model.forward_over_time(these_examples[:, :3].to('cuda' if self.is_cuda else 'cpu').long())
+                    time_loss = loss(time_predictions, truth.to('cuda' if self.is_cuda else 'cpu'))
 
                 l_reg = self.emb_regularizer.forward(factors)
                 l_time = torch.zeros_like(l_reg)


### PR DESCRIPTION
For some users that don't have access to a CUDA machine, I have added a property --gpu to training the models on the dataset, where it can take either (0, or 1) 0 = False meaning use CPU, and 1 = True use CUDA
- --gpu 0 will use CPU.
- --gpu 1 will use CUDA